### PR TITLE
US Privacy framework (CCPA) support

### DIFF
--- a/__tests__/cookie.spec.js
+++ b/__tests__/cookie.spec.js
@@ -1,0 +1,26 @@
+import sinon from "sinon";
+import { getCookieValue } from "../source/cookie.js";
+
+describe("cookie", function() {
+    let win;
+
+    beforeEach(function() {
+        win = {
+            document: {
+                cookie:
+                    "_ga=GA1.2.388359608.1543305257; _octo=GH1.1.639453252.1543305257; tz=Europe%2FHelsinki; us_privacy=1YN-"
+            }
+        };
+    });
+
+    describe("getCookieValue", function() {
+        it("returns correct value", function() {
+            expect(getCookieValue(win, "us_privacy")).toEqual("1YN-");
+            expect(getCookieValue(win, "_ga")).toEqual("GA1.2.388359608.1543305257");
+        });
+
+        it("returns the default value if not found", function() {
+            expect(getCookieValue(win, "not-here", false)).toBe(false);
+        });
+    });
+});

--- a/__tests__/usp.spec.js
+++ b/__tests__/usp.spec.js
@@ -1,0 +1,23 @@
+import { uspApplies } from "../source/usp.js";
+
+describe("usp", function() {
+    describe("uspApplies", function() {
+        it("correctly identifies valid USP strings", function() {
+            expect(uspApplies("1NNN")).toBe(true);
+            expect(uspApplies("1N--")).toBe(true);
+            expect(uspApplies("1YN-")).toBe(true);
+        });
+
+        it("correctly identifies invalid USP strings", function() {
+            expect(uspApplies("")).toBe(false);
+            expect(uspApplies("----")).toBe(false);
+            expect(uspApplies("x")).toBe(false);
+            expect(uspApplies()).toBe(false);
+            expect(uspApplies(0)).toBe(false);
+        });
+
+        it("correctly identifies non-application USP string", function() {
+            expect(uspApplies("1---")).toBe(false);
+        });
+    });
+});

--- a/source/accessors.js
+++ b/source/accessors.js
@@ -255,7 +255,7 @@ export function onGoogleConsent(cb, options = {}) {
 export function onUSPString(cb, options = {}) {
     const { mem: memInst = createMem(), win = window } = options;
     let live = true;
-    getConsentData({ mem: memInst, noConsent: "resolve", type: "usp", win })
+    getConsentData({ mem: memInst, /*noConsent: "resolve",*/ type: "usp", win })
         .then(uspString => {
             if (!live) {
                 return;

--- a/source/consent.js
+++ b/source/consent.js
@@ -1,5 +1,6 @@
 import { startTimer, stopTimer } from "./timer.js";
 import { getCookieValue } from "./cookie.js";
+import { isUSPString } from "./usp.js";
 
 /**
  * @typedef {Object} ConsentPayload
@@ -126,16 +127,6 @@ export function isGooglePayload(payload) {
         payload.googlePersonalizationData &&
         typeof payload.googlePersonalizationData === "object"
     );
-}
-
-/**
- * Test if a string is a valid USP string
- * @param {String} str The string to check
- * @returns {Boolean} True if valid, false otherwise
- * @private
- */
-function isUSPString(str) {
-    return /^1[YN-]{3}$/i.test(str);
 }
 
 /**

--- a/source/cookie.js
+++ b/source/cookie.js
@@ -1,0 +1,17 @@
+export function getCookieValue(win, cookieName, defaultValue) {
+    let cookies;
+    try {
+        cookies = win.document.cookie.split(";");
+    } catch (err) {
+        return defaultValue;
+    }
+    for (const cookie of cookies) {
+        try {
+            const [key, value = ""] = cookie.split("=").map(item => item.trim());
+            if (key === cookieName) {
+                return value;
+            }
+        } catch (err) {}
+    }
+    return defaultValue;
+}

--- a/source/index.js
+++ b/source/index.js
@@ -11,6 +11,7 @@ export {
     onVendorConsent
 } from "./accessors.js";
 export { createMem } from "./mem.js";
+export { uspApplies } from "./usp.js";
 
 /**
  * @module GetConsent

--- a/source/index.js
+++ b/source/index.js
@@ -2,10 +2,12 @@ export {
     getConsentData,
     getConsentString,
     getGoogleConsent,
+    getUSPString,
     getVendorConsentData,
     onConsentData,
     onConsentString,
     onGoogleConsent,
+    onUSPString,
     onVendorConsent
 } from "./accessors.js";
 export { createMem } from "./mem.js";

--- a/source/usp.js
+++ b/source/usp.js
@@ -1,0 +1,27 @@
+/**
+ * Test if a string is a valid USP string
+ * @param {String} str The string to check
+ * @returns {Boolean} True if valid, false otherwise
+ * @private
+ */
+export function isUSPString(str) {
+    return typeof str === "string" && /^1[YN-]{3}$/i.test(str);
+}
+
+/**
+ * Detect whether or not a value is indicative of
+ * USP applying to the user
+ * @param {String|*} str The USP string or value
+ * @returns {Boolean} Whether or not a value is a
+ *  USP string and whether or not USP applies due
+ *  to it
+ * @memberof module:GetConsent
+ */
+export function uspApplies(str) {
+    if (!isUSPString(str)) {
+        return false;
+    }
+    // Documented by IAB to indicate a condition where the
+    // US privacy framework does NOT apply:
+    return str !== "1---";
+}


### PR DESCRIPTION
Added new methods to fetch USP string, using the following methods:

 * `window.__uspapi` API
 * `__uspapiCall` postMessage
 * `us_privacy` cookie

Very similiar to the GDPR/google-personalization items.